### PR TITLE
fix(qmclient): 移除线性缩放与设置页字体独立缩放

### DIFF
--- a/src/engine/shared/config_variables_qmclient.h
+++ b/src/engine/shared/config_variables_qmclient.h
@@ -24,8 +24,6 @@ MACRO_CONFIG_INT(QmAssetsPreviewBudgetPercent, qm_assets_preview_budget_percent,
 MACRO_CONFIG_INT(QmUiRuntimeV2Debug, qm_ui_runtime_v2_debug, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable UI runtime v2 debug logging")
 MACRO_CONFIG_INT(QmUiMotionLevel, qm_ui_motion_level, 2, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "QmUi animation intensity: 0=Off, 1=Reduced, 2=Full")
 MACRO_CONFIG_INT(QmUiScale, qm_ui_scale, 100, 50, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Global UI size percentage")
-MACRO_CONFIG_INT(QmSettingsFontScale, qm_settings_font_scale, 100, 80, 160, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Settings page font size percentage (independent of UI scale)")
-MACRO_CONFIG_INT(QmZoomLinear, qm_zoom_linear, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Zoom+/- uses linear interpolation instead of cubic bezier damping")
 MACRO_CONFIG_INT(QmUiListEntryAnimations, qm_ui_list_entry_animations, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Animate lists when entering a page")
 MACRO_CONFIG_INT(QmUiCardHeightAnimations, qm_ui_card_height_animations, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Animate settings card expand and collapse height changes")
 MACRO_CONFIG_INT(QmUiCardReflowAnimations, qm_ui_card_reflow_animations, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Animate settings card reorder and layout reflow")

--- a/src/game/client/QmUi/SettingsCard.cpp
+++ b/src/game/client/QmUi/SettingsCard.cpp
@@ -132,7 +132,7 @@ SSettingsCardFrame SettingsCard(const IUiContext &Ctx, const SSettingsCardFrame 
 			SLabelProperties SubtitleProps;
 			SubtitleProps.m_MaxWidth = DrawFrame.m_SubtitleRect.w;
 			SubtitleProps.m_EllipsisAtEnd = true;
-			const float SubtitleSize = ResolveSettingsSmallFontSize(UiScale) * NormalizeSettingsFontScale(g_Config.m_QmSettingsFontScale);
+			const float SubtitleSize = ResolveSettingsSmallFontSize(UiScale);
 			Ctx.m_pUi->DoLabel(&DrawFrame.m_SubtitleRect, pSubtitle, SubtitleSize, TEXTALIGN_ML, SubtitleProps);
 		}
 		// 标题和副标题只影响本卡片，不能把调用方的文本状态写死为默认白色。

--- a/src/game/client/QmUi/SettingsPageLayout.h
+++ b/src/game/client/QmUi/SettingsPageLayout.h
@@ -150,26 +150,15 @@ inline float ResolveSettingsSmallFontSize(const float UiScale)
 	return std::clamp(ui_token::font::SMALL * std::max(0.0f, UiScale), 9.0f, ui_token::font::SMALL);
 }
 
-// 设置页字体缩放系数（纯函数，无配置依赖）。Percent=100 为原尺寸
-inline float NormalizeSettingsFontScale(const int FontScalePercent)
-{
-	return std::clamp(FontScalePercent / 100.0f, 0.80f, 1.60f);
-}
-
-// FontScalePercent：设置页字体百分比，调用方负责从配置读入（默认 100 保持原行为）
-inline SSettingsContentMetrics ResolveSettingsContentMetrics(const float ContentWidth, const float FontScalePercent = 100.0f)
+inline SSettingsContentMetrics ResolveSettingsContentMetrics(const float ContentWidth)
 {
 	SSettingsContentMetrics Metrics;
 	Metrics.m_UiScale = ResolveSettingsUiScale(ContentWidth);
-	// 设置页字体独立缩放：响应“设置字体偏小”，不牵动整体布局比例
-	const float FontScale = NormalizeSettingsFontScale((int)FontScalePercent);
-	// 行高与字号同比例放大，避免高缩放下文字被裁切
-	const float RowFactor = FontScale;
-	Metrics.m_LineHeight = std::clamp(ui_token::settings::ROW_HEIGHT * Metrics.m_UiScale * RowFactor, 16.0f, ui_token::settings::ROW_HEIGHT * 1.60f);
-	Metrics.m_BodySize = std::clamp(ui_token::font::BODY * Metrics.m_UiScale * FontScale, 10.0f, ui_token::font::BODY * 1.5f);
-	Metrics.m_SmallSize = std::clamp(ui_token::font::SMALL * std::max(0.0f, Metrics.m_UiScale) * FontScale, 9.0f, ui_token::font::SMALL * 1.5f);
-	Metrics.m_HeadlineSize = std::clamp(ui_token::font::HEADLINE * Metrics.m_UiScale * FontScale, 12.0f, ui_token::font::HEADLINE * 1.4f);
-	Metrics.m_LineSpacing = std::clamp(ui_token::settings::ROW_GAP * Metrics.m_UiScale * RowFactor, 3.0f, ui_token::settings::ROW_GAP * 1.60f);
+	Metrics.m_LineHeight = std::clamp(ui_token::settings::ROW_HEIGHT * Metrics.m_UiScale, 16.0f, ui_token::settings::ROW_HEIGHT);
+	Metrics.m_BodySize = std::clamp(ui_token::font::BODY * Metrics.m_UiScale, 10.0f, ui_token::font::BODY);
+	Metrics.m_SmallSize = ResolveSettingsSmallFontSize(Metrics.m_UiScale);
+	Metrics.m_HeadlineSize = std::clamp(ui_token::font::HEADLINE * Metrics.m_UiScale, 12.0f, ui_token::font::HEADLINE);
+	Metrics.m_LineSpacing = std::clamp(ui_token::settings::ROW_GAP * Metrics.m_UiScale, 3.0f, ui_token::settings::ROW_GAP);
 	Metrics.m_RowStep = Metrics.m_LineHeight + Metrics.m_LineSpacing;
 	Metrics.m_InputHeight = Metrics.m_LineHeight;
 	Metrics.m_ButtonHeight = Metrics.m_LineHeight;
@@ -586,7 +575,7 @@ inline float ResolveSettingsControllerAxisPickerHeight(const int AxisCount, cons
 	return (std::clamp(AxisCount, 0, std::max(0, MaxAxisCount)) + 1) * (std::max(0.0f, RowHeight) + std::max(0.0f, RowSpacing));
 }
 
-inline float ResolveSettingsControllerContentHeight(const float ContentWidth, const bool Enabled, const bool HasJoystick, const bool AbsoluteMode, const int AxisCount, const int MaxAxisCount, const float RowHeight, const float RowSpacing, const float FontScalePercent = 100.0f)
+inline float ResolveSettingsControllerContentHeight(const float ContentWidth, const bool Enabled, const bool HasJoystick, const bool AbsoluteMode, const int AxisCount, const int MaxAxisCount, const float RowHeight, const float RowSpacing)
 {
 	float Height = std::max(0.0f, RowHeight) + std::max(0.0f, RowSpacing);
 	if(!Enabled)
@@ -596,7 +585,7 @@ inline float ResolveSettingsControllerContentHeight(const float ContentWidth, co
 	if(!HasJoystick)
 		return Height + std::max(0.0f, RowSpacing);
 
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth, FontScalePercent);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth);
 	const SSettingsRadioRowLayout Radio = ResolveSettingsRadioRowLayout({0.0f, 0.0f, std::max(0.0f, ContentWidth), RowHeight * 2.0f + RowSpacing}, 2, Metrics);
 	Height += Radio.m_Height;
 	if(!AbsoluteMode)

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -78,8 +78,6 @@ CCamera::CCamera()
 	m_ZoomSet = false;
 	m_Zoom = 1.0f;
 	m_Zooming = false;
-	m_ZoomSmoothingFrom = 1.0f;
-	m_ZoomSmoothingTarget = 1.0f;
 	m_ForceFreeview = false;
 	m_GotoSwitchOffset = 0;
 	m_GotoTeleOffset = 0;
@@ -117,20 +115,13 @@ CCamera::CCamera()
 
 float CCamera::CameraSmoothingProgress(float CurrentTime) const
 {
-	const float Duration = m_CameraSmoothingEnd - m_CameraSmoothingStart;
-	if(Duration <= 0.0f)
-		return 1.0f;
-	const float Progress = (CurrentTime - m_CameraSmoothingStart) / Duration;
-	return 1.0 - std::pow(2.0, -10.0 * std::clamp(Progress, 0.0f, 1.0f));
+	float Progress = (CurrentTime - m_CameraSmoothingStart) / (m_CameraSmoothingEnd - m_CameraSmoothingStart);
+	return 1.0 - std::pow(2.0, -10.0 * Progress);
 }
 
 float CCamera::ZoomProgress(float CurrentTime) const
 {
-	// Smoothness=0 时 Start==End，避免除零得到 NaN
-	const float Duration = m_ZoomSmoothingEnd - m_ZoomSmoothingStart;
-	if(Duration <= 0.0f)
-		return 1.0f;
-	return std::clamp((CurrentTime - m_ZoomSmoothingStart) / Duration, 0.0f, 1.0f);
+	return (CurrentTime - m_ZoomSmoothingStart) / (m_ZoomSmoothingEnd - m_ZoomSmoothingStart);
 }
 
 void CCamera::ScaleZoom(float Factor)
@@ -161,18 +152,17 @@ void CCamera::ChangeZoom(float Target, int Smoothness, bool IsUser)
 	}
 
 	float Now = Client()->LocalTime();
-	// 中断时以 m_Zoom 为起点：线性路径与贝塞尔路径都保证视觉连续，避免模式切换跳变
 	float Current = m_Zoom;
 	float Derivative = 0.0f;
-	if(m_Zooming && !g_Config.m_QmZoomLinear)
+	if(m_Zooming)
 	{
-		const float Progress = ZoomProgress(Now);
+		float Progress = ZoomProgress(Now);
+		Current = m_ZoomSmoothing.Evaluate(Progress);
 		Derivative = m_ZoomSmoothing.Derivative(Progress);
 	}
 
 	m_ZoomSmoothingTarget = Target;
 	m_ZoomSmoothing = CCubicBezier::With(Current, Derivative, 0, m_ZoomSmoothingTarget);
-	m_ZoomSmoothingFrom = Current;
 	m_ZoomSmoothingStart = Now;
 	m_ZoomSmoothingEnd = Now + (float)Smoothness / 1000;
 
@@ -267,16 +257,7 @@ void CCamera::UpdateCamera()
 		else
 		{
 			const float OldLevel = m_Zoom;
-			// 线性模式：匀速过渡，去掉贝塞尔阻尼感；否则保持原贝塞尔曲线
-			if(g_Config.m_QmZoomLinear)
-			{
-				const float Progress = std::clamp(ZoomProgress(Time), 0.0f, 1.0f);
-				m_Zoom = m_ZoomSmoothingFrom + (m_ZoomSmoothingTarget - m_ZoomSmoothingFrom) * Progress;
-			}
-			else
-			{
-				m_Zoom = m_ZoomSmoothing.Evaluate(ZoomProgress(Time));
-			}
+			m_Zoom = m_ZoomSmoothing.Evaluate(ZoomProgress(Time));
 			if((OldLevel < m_ZoomSmoothingTarget && m_Zoom > m_ZoomSmoothingTarget) || (OldLevel > m_ZoomSmoothingTarget && m_Zoom < m_ZoomSmoothingTarget))
 			{
 				m_Zoom = m_ZoomSmoothingTarget;

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -64,8 +64,6 @@ private:
 	CCubicBezier m_ZoomSmoothing;
 	float m_ZoomSmoothingStart;
 	float m_ZoomSmoothingEnd;
-	// 线性缩放模式下记录起始倍率，用于 lerp，避免贝塞尔阻尼感
-	float m_ZoomSmoothingFrom;
 
 	void ScaleZoom(float Factor);
 	void ChangeZoom(float Target, int Smoothness, bool IsUser);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -4739,7 +4739,7 @@ void CMenus::RenderThemeSelection(CUIRect MainView, const SSettingsContentMetric
 	CPerfTimer RenderTimer;
 	static CListBox s_ListBox;
 	auto &MenuBackground = GameClient()->m_MenuBackground;
-	const SSettingsContentMetrics Metrics = pMetrics != nullptr ? *pMetrics : ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = pMetrics != nullptr ? *pMetrics : ResolveSettingsContentMetrics(MainView.w);
 	s_ListBox.SetScrollProfile(EQmScrollProfile::SETTINGS_INNER);
 	s_ListBox.SetWheelOwnerPriority(EUiWheelOwnerPriority::COMPOSITE_CONTROL);
 	s_ListBox.SetItemColors(ui_token::color::LIST_ITEM_SELECTED, ui_token::color::LIST_ITEM_SELECTED, ui_token::color::LIST_ITEM_HOVER);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -752,7 +752,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 {
 	CPerfTimer RenderTimer;
 	CScopedSettingsTextPerfStats TextStats(this);
-	const SSettingsContentMetrics GeneralMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics GeneralMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = GeneralMetrics.m_UiScale;
 	const float BodySize = GeneralMetrics.m_BodySize;
 	const SSettingsListCardGeometry GeneralLanguageGeometry = ResolveSettingsGeneralLanguageListGeometry((int)g_Localization.Languages().size(), GeneralMetrics);
@@ -1163,7 +1163,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 {
 	CPerfTimer RenderTimer;
 	CScopedSettingsTextPerfStats TextStats(this);
-	const SSettingsContentMetrics PlayerMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics PlayerMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = PlayerMetrics.m_UiScale;
 	const float BodySize = PlayerMetrics.m_BodySize;
 	const IUiContext PlayerCardCtx = SettingsUiContext("settings_player", UiScale);
@@ -1354,7 +1354,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 {
 	CPerfTimer RenderTimer;
 	CScopedSettingsTextPerfStats TextStats(this);
-	const SSettingsContentMetrics TeeMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics TeeMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = TeeMetrics.m_UiScale;
 	const float BodySize = TeeMetrics.m_BodySize;
 	const IUiContext TeeCardCtx = SettingsUiContext("settings_tee", UiScale);
@@ -3599,7 +3599,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	}
 
 	const float ViewWidth = MainView.w;
-	const SSettingsContentMetrics GraphicsMetrics = ResolveSettingsContentMetrics(ViewWidth, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics GraphicsMetrics = ResolveSettingsContentMetrics(ViewWidth);
 	const float UiScale = GraphicsMetrics.m_UiScale;
 	const float BodySize = GraphicsMetrics.m_BodySize;
 
@@ -4665,7 +4665,7 @@ bool CMenus::AudioPackEditorCopyAbsoluteFileToStorage(const char *pSourcePath, c
 
 void CMenus::RenderAudioPackEditorScreen(CUIRect MainView)
 {
-	const SSettingsContentMetrics EditorMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics EditorMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float EditorFontSize = EditorMetrics.m_BodySize;
 	const float EditorSecondaryFontSize = maximum(9.0f, EditorFontSize - 2.0f);
 	const float EditorLineSize = EditorMetrics.m_LineHeight;
@@ -5092,7 +5092,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		s_SndPackInit = true;
 	}
 
-	const SSettingsContentMetrics SoundMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics SoundMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = SoundMetrics.m_UiScale;
 	const float BodySize = SoundMetrics.m_BodySize;
 	const float LineHeight = SoundMetrics.m_LineHeight;
@@ -5410,7 +5410,7 @@ void CMenus::PrepareLanguagePageCache(float MainViewWidth, bool ForceComplete)
 
 	CUIRect List;
 	LayoutLanguagePageBaseRects(MainViewWidth, List);
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainViewWidth, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainViewWidth);
 
 	const float LabelWidth = LanguageListLabelWidth(List, Metrics);
 	const bool LanguageChanged = str_comp(gs_aLanguageCacheLanguageFile, g_Config.m_ClLanguagefile) != 0;
@@ -5476,7 +5476,7 @@ void CMenus::RenderLanguageSettings(CUIRect MainView)
 	CPerfTimer RenderTimer;
 	const char *pCreditsText = Localize("English translation by the DDNet Team", "Translation credits: Add your own name here when you update translations");
 	const int NumLanguages = (int)g_Localization.Languages().size();
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	EnsureLanguagePageCacheInit(Ui());
 
 	CUIRect Header, CreditsButton, List;
@@ -5510,7 +5510,7 @@ bool CMenus::RenderLanguageSelection(CUIRect MainView, const SSettingsContentMet
 	static int s_SelectedLanguage = -2; // -2 = unloaded, -1 = unset
 	EnsureLanguagePageCacheInit(Ui());
 	const bool UseCache = UseLanguagePageCache();
-	const SSettingsContentMetrics Metrics = pMetrics != nullptr ? *pMetrics : ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = pMetrics != nullptr ? *pMetrics : ResolveSettingsContentMetrics(MainView.w);
 
 	if(s_SelectedLanguage == -2)
 	{
@@ -5668,7 +5668,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 	{
 		const SSettingsShellLayoutFrame Shell = ResolveSettingsShellLayout(MainView, NeedRestart ? 30.0f : 0.0f);
 		m_SettingsShellLayout = Shell;
-		m_SettingsContentMetrics = ResolveSettingsContentMetrics(Shell.m_ContentRect.w, g_Config.m_QmSettingsFontScale);
+		m_SettingsContentMetrics = ResolveSettingsContentMetrics(Shell.m_ContentRect.w);
 		m_SettingsShellLayoutValid = true;
 		MainView = Shell.m_ContentRect;
 		TabBar = Shell.m_TabBarRect;
@@ -5688,7 +5688,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 		if(!CollectingMenuTextPlan)
 			MainView.Draw(ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
 		MainView.Margin(std::clamp(MainView.w * 0.02f, 12.0f, 20.0f), &MainView);
-		m_SettingsContentMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+		m_SettingsContentMetrics = ResolveSettingsContentMetrics(MainView.w);
 	}
 	const float PreviousDropDownFontSize = Ui()->DropDownFontSize();
 	Ui()->SetDropDownFontSize(m_SettingsContentMetrics.m_BodySize);
@@ -6013,7 +6013,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 	if(NeedRestart)
 	{
 		const int64_t StageStartTime = PerfDebugStartTime();
-		const SSettingsContentMetrics RestartMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+		const SSettingsContentMetrics RestartMetrics = ResolveSettingsContentMetrics(MainView.w);
 		CUIRect RestartWarning, RestartButton;
 		RestartBar.VSplitRight(125.0f * RestartMetrics.m_UiScale, &RestartWarning, &RestartButton);
 		RestartWarning.VSplitRight(RestartMetrics.m_SectionGap, &RestartWarning, nullptr);
@@ -6344,7 +6344,7 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 
 void CMenus::RenderSettingsAppearance(CUIRect MainView)
 {
-	const SSettingsContentMetrics AppearanceMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics AppearanceMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float AppearanceUiScale = AppearanceMetrics.m_UiScale;
 	const float AppearanceBodySize = AppearanceMetrics.m_BodySize;
 
@@ -7933,7 +7933,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	CUIRect Button, Left, Right, LeftLeft, Label;
 	LogPerfStage(Client(), "ddnet_tab_shell", ShellTimer.ElapsedMs(), false, "page=ddnet");
 
-	const SSettingsContentMetrics DDNetMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics DDNetMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = DDNetMetrics.m_UiScale;
 	const float BodySize = DDNetMetrics.m_BodySize;
 	const float DDNetRowPitch = DDNetMetrics.m_LineHeight + DDNetMetrics.m_LineSpacing;

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -42,7 +42,7 @@ using namespace FontIcons;
 
 void CMenus::RenderSettingsTee7(CUIRect MainView)
 {
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = Metrics.m_UiScale;
 	const SSettingsPageLayoutFrame Page = SettingsPageLayout(MainView, UiScale);
 	const qm_card_registry::SCardDefault *pEditorDefault = qm_card_registry::FindByStableId("deck:tee7-editor");

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -4155,7 +4155,7 @@ static int InitSearchList(std::vector<TName *> &vpSearchList, std::vector<TName>
 
 void CMenus::RenderSettingsCustom(CUIRect MainView)
 {
-	const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(MainView.w);
 	s_CurCustomTab = std::clamp(s_CurCustomTab, (int)ASSETS_TAB_ENTITIES, NUMBER_OF_ASSETS_TABS - 1);
 
 	if(m_AssetsEditorState.m_Open)

--- a/src/game/client/components/menus_settings_controls.cpp
+++ b/src/game/client/components/menus_settings_controls.cpp
@@ -49,7 +49,7 @@ namespace
 
 	void ApplyControlsContentMetrics(const float ContentWidth)
 	{
-		const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth, g_Config.m_QmSettingsFontScale);
+		const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth);
 		HEADER_FONT_SIZE = std::clamp(ui_token::font::HEADLINE * Metrics.m_UiScale, 13.0f, ui_token::font::HEADLINE);
 		FONT_SIZE = Metrics.m_BodySize;
 		BUTTON_HEIGHT = Metrics.m_LineHeight;
@@ -338,7 +338,7 @@ void CMenusSettingsControls::Render(CUIRect MainView)
 			Content.HSplitTop(BUTTON_SPACING, nullptr, &Content);
 			Content.HSplitTop(BUTTON_HEIGHT, nullptr, &Content);
 
-			const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(Content.w, g_Config.m_QmSettingsFontScale);
+			const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(Content.w);
 			const bool WasAbsolute = g_Config.m_InpControllerAbsolute != 0;
 			const SSettingsRadioRowLayout ModeLayout = ResolveSettingsRadioRowLayout(Content, 2, Metrics);
 			CUIRect ModeButtons = ModeLayout.m_ButtonsRect;
@@ -784,7 +784,7 @@ void CMenusSettingsControls::RenderSettingsJoystick(CUIRect View, bool ReadOnly)
 			{Localize("Relative", "Ingame controller mode"), Localize("Absolute", "Ingame controller mode")},
 			{0, 1},
 			g_Config.m_InpControllerAbsolute,
-			ResolveSettingsContentMetrics(View.w, g_Config.m_QmSettingsFontScale));
+			ResolveSettingsContentMetrics(View.w));
 
 		if(!WasAbsolute) // Use old value because this was used to allocate the available height
 		{

--- a/src/game/client/components/qmclient/menus_qmclient.cpp
+++ b/src/game/client/components/qmclient/menus_qmclient.cpp
@@ -1260,9 +1260,6 @@ void CMenus::RenderQmVisualCameraViewContent(CUIRect &Content, float LineHeight,
 	RenderQmVisualCheckbox(Content, LineHeight, LineSpacing, &g_Config.m_QmCinematicCamera, "Cinematic camera", Localize("Cinematic camera"), &g_Config.m_QmCinematicCamera);
 	static int s_QmUiScaleInputId;
 	RenderValue("qmclient-ui-scale", "UI scale", &s_QmUiScaleInputId, &g_Config.m_QmUiScale, 50, 200, "%", CUi::SCROLLBAR_OPTION_DELAYUPDATE);
-	static int s_QmSettingsFontScaleInputId;
-	RenderValue("qmclient-settings-font-scale", "Settings font scale", &s_QmSettingsFontScaleInputId, &g_Config.m_QmSettingsFontScale, 80, 160, "%", CUi::SCROLLBAR_OPTION_DELAYUPDATE);
-	RenderQmVisualCheckbox(Content, LineHeight, LineSpacing, &g_Config.m_QmZoomLinear, "Linear zoom (no damping)", Localize("Linear zoom (no damping)"), &g_Config.m_QmZoomLinear);
 	const char *apAspectPresetNames[] = {Localize("Off"), "5:4", "4:3", "3:2", "16:9", "21:9", Localize("Custom")};
 	static CUi::SDropDownState s_AspectPresetDropDownState;
 	static CScrollRegion s_AspectPresetDropDownScrollRegion;
@@ -1360,7 +1357,7 @@ void CMenus::FinishSettingsQmScrollContainer(CQmScrollState &ScrollState, CQmScr
 void CMenus::RenderSettingsQmClientContributors(CUIRect MainView, bool PrewarmOnly)
 {
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = Metrics.m_UiScale;
 	const float BodySize = Metrics.m_BodySize;
 	const float LineHeight = Metrics.m_LineHeight;
@@ -4283,7 +4280,7 @@ void CMenus::RenderSettingsQmClientHudDeck(CUIRect MainView, bool PrewarmOnly)
 {
 	using namespace qm_module;
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = Metrics.m_UiScale;
 	const float LineHeight = Metrics.m_LineHeight;
 	const float BodySize = Metrics.m_BodySize;
@@ -4598,7 +4595,7 @@ void CMenus::RenderSettingsQmClientFunctionDeck(CUIRect MainView, bool PrewarmOn
 {
 	using namespace qm_module;
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = Metrics.m_UiScale;
 	const float LineHeight = Metrics.m_LineHeight;
 	const float BodySize = Metrics.m_BodySize;
@@ -4827,7 +4824,7 @@ void CMenus::RenderSettingsQmClientVisualDeck(CUIRect MainView, bool PrewarmOnly
 {
 	using namespace qm_module;
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = Metrics.m_UiScale;
 	const float LineHeight = Metrics.m_LineHeight;
 	const float BodySize = Metrics.m_BodySize;
@@ -4871,7 +4868,7 @@ void CMenus::RenderSettingsQmClientVisualDeck(CUIRect MainView, bool PrewarmOnly
 		case EQmModuleId::ChatBubble:
 			return g_Config.m_QmChatBubble ? Rows(5.0f) + 2.0f * Metrics.m_LineHeight + 2.0f * Metrics.m_LineSpacing : Rows(1.0f);
 		case EQmModuleId::CameraView:
-			return Rows(7.0f + (g_Config.m_QmCameraDrift ? 3.0f : 0.0f) + (g_Config.m_QmDynamicFov ? 2.0f : 0.0f) + (g_Config.m_QmAspectPreset == 6 ? 1.0f : 0.0f)) + Metrics.m_BodySize;
+			return Rows(5.0f + (g_Config.m_QmCameraDrift ? 3.0f : 0.0f) + (g_Config.m_QmDynamicFov ? 2.0f : 0.0f) + (g_Config.m_QmAspectPreset == 6 ? 1.0f : 0.0f)) + Metrics.m_BodySize;
 		case EQmModuleId::SkinTransition:
 			return ResolveQmVisualSkinTransitionHeight(Metrics, g_Config.m_QmSkinChangeTransition != 0);
 		case EQmModuleId::FocusMode:
@@ -4944,11 +4941,6 @@ void CMenus::RenderSettingsQmClientVisualDeck(CUIRect MainView, bool PrewarmOnly
 					ConsumeVisualRow(Content);
 				}
 				Changed = HandleQmHudCheckboxInput(Content, LineHeight, LineSpacing, &g_Config.m_QmCinematicCamera, &g_Config.m_QmCinematicCamera) || Changed;
-				// UI scale / settings font scale / linear zoom / aspect rows
-				ConsumeVisualRow(Content);
-				ConsumeVisualRow(Content);
-				Changed = HandleQmHudCheckboxInput(Content, LineHeight, LineSpacing, &g_Config.m_QmZoomLinear, &g_Config.m_QmZoomLinear) || Changed;
-				ConsumeVisualRow(Content);
 				return Changed;
 			};
 		case EQmModuleId::SkinTransition:
@@ -5067,7 +5059,7 @@ void CMenus::RenderSettingsQmClient(CUIRect MainView, bool ContributorsPage, boo
 
 void CMenus::RenderSettingsGlobalSearchContent(CUIRect MainView, bool PrewarmOnly)
 {
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	const float UiScale = Metrics.m_UiScale;
 	const float BodySize = Metrics.m_BodySize;
 	const float SmallSize = Metrics.m_SmallSize;
@@ -5239,7 +5231,7 @@ void CMenus::RenderSettingsQmClientContent(CUIRect MainView, bool ContributorsPa
 	}
 
 	CPerfTimer RenderTimer;
-	const float QmClientUiScale = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale).m_UiScale;
+	const float QmClientUiScale = ResolveSettingsContentMetrics(MainView.w).m_UiScale;
 	bool TabTransitionActive = false;
 	static bool s_QmTabTelemetryInitialized = false;
 	static int s_PrevQmTab = QMCLIENT_SETTINGS_TAB_VISUAL;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -592,7 +592,7 @@ public:
 
 static void ApplyTClientContentMetrics(const float ContentWidth)
 {
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth);
 	FontSize = Metrics.m_BodySize;
 	EditBoxFontSize = Metrics.m_BodySize;
 	LineSize = Metrics.m_LineHeight;
@@ -616,7 +616,7 @@ static constexpr const char *SETTINGS_RUNTIME_CACHE_METADATA_FILE = "qmclient/se
 
 CUIRect TClientSettingsContentView(CUIRect MainView, CUIRect *pTabBar = nullptr)
 {
-	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(MainView.w);
 	const SSettingsSubTabLayoutFrame SubTabs = ResolveSettingsSubTabLayout(MainView, Metrics.m_UiScale);
 	if(pTabBar != nullptr)
 		*pTabBar = SubTabs.m_TabBarRect;
@@ -2052,7 +2052,7 @@ void CMenus::RenderSettingsTClientSettings(CUIRect MainView, bool PrewarmOnly)
 				DoSettingsMenuLabel(SETTINGS_TCLIENT, m_TClientSettingsTab, m_TClientSettingsTab, nullptr, &Label, Localize("Visual: Effects"), HeadlineFontSize, TEXTALIGN_ML);
 			CurrentColumn.HSplitTop(MarginSmall, nullptr, &CurrentColumn);
 			CTClientSettingsRowAllocator Rows(CurrentColumn);
-			const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(CurrentColumn.w, g_Config.m_QmSettingsFontScale);
+			const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(CurrentColumn.w);
 			const float TinyTeeModeHeight = ResolveSettingsRadioRowLayout(CurrentColumn, 3, ContentMetrics).m_Height;
 			const bool RenderTinyTeeMode = ShouldRenderVisualBlock(TinyTeeModeHeight);
 			CUIRect Row = Rows.Next(TinyTeeModeHeight);
@@ -2335,7 +2335,7 @@ void CMenus::RenderSettingsTClientSettings(CUIRect MainView, bool PrewarmOnly)
 				DoSettingsMenuLabel(SETTINGS_TCLIENT, m_TClientSettingsTab, m_TClientSettingsTab, nullptr, &Label, Localize("Voting"), HeadlineFontSize, TEXTALIGN_ML);
 			CurrentColumn.HSplitTop(MarginSmall, nullptr, &CurrentColumn);
 			CTClientSettingsRowAllocator Rows(CurrentColumn);
-			const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+			const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(MainView.w);
 			const float AutoVoteHeight = ResolveSettingsRadioRowLayout(CurrentColumn, 3, ContentMetrics).m_Height;
 			CUIRect Row = Rows.Next(AutoVoteHeight);
 
@@ -3671,7 +3671,7 @@ void CMenus::RenderSettingsTClientSettings(CUIRect MainView, bool PrewarmOnly)
 					if(m_MenuTextPlanCollecting)
 						return false;
 					CTClientSettingsRowAllocator Rows(Content);
-					const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(Content.w, g_Config.m_QmSettingsFontScale);
+					const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(Content.w);
 					const CUIRect TinyTeeModeRow = Rows.Next(ResolveSettingsRadioRowLayout(Content, 3, ContentMetrics).m_Height);
 					const SSettingsRadioRowLayout TinyTeeModeLayout = ResolveSettingsRadioRowLayout(TinyTeeModeRow, 3, ContentMetrics);
 					CUIRect TinyTeeModeButtons = TinyTeeModeLayout.m_ButtonsRect;
@@ -3886,7 +3886,7 @@ void CMenus::RenderSettingsTClientBindWheel(CUIRect MainView, bool PrewarmOnly)
 	ApplyTClientContentMetrics(MainView.w);
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
 	const float UiScale = SettingsPageUiScale(MainView.w);
-	const float SmallSize = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale).m_SmallSize;
+	const float SmallSize = ResolveSettingsContentMetrics(MainView.w).m_SmallSize;
 	const SSettingsPageLayoutFrame Page = SettingsPageLayout(MainView, UiScale);
 	IUiContext TClientBindWheelTextInputCtx = SettingsUiContext("settings_tclient_bindwheel_text_inputs", UiScale);
 	if(ReadOnly)
@@ -4217,7 +4217,7 @@ void CMenus::RenderSettingsTClientWarList(CUIRect MainView, bool PrewarmOnly)
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
 	const float UiScale = SettingsPageUiScale(MainView.w);
 	const SSettingsPageLayoutFrame Page = SettingsPageLayout(MainView, UiScale);
-	const SSettingsContentMetrics WarListMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics WarListMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const float ListRowHeight = WarListMetrics.m_ListRowHeight;
 	constexpr int WarListViewportRows = 8;
 	std::unique_ptr<CUiRenderOnlyGuard> pRenderOnlyGuard;
@@ -5546,7 +5546,7 @@ void CMenus::RenderSettingsTClientProfiles(CUIRect MainView, bool PrewarmOnly)
 	CPerfTimer RenderTimer;
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
 	const float UiScale = SettingsPageUiScale(MainView.w);
-	const SSettingsContentMetrics ProfileMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics ProfileMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const SSettingsPageLayoutFrame Page = SettingsPageLayout(MainView, UiScale);
 	std::unique_ptr<CUiRenderOnlyGuard> pRenderOnlyGuard;
 	if(ReadOnly && !Ui()->RenderOnly())
@@ -6001,7 +6001,7 @@ void CMenus::RenderSettingsTClientConfigs(CUIRect MainView, bool PrewarmOnly)
 	CPerfTimer RenderTimer;
 	const bool ReadOnly = PrewarmOnly || Ui()->RenderOnly();
 	const float UiScale = SettingsPageUiScale(MainView.w);
-	const SSettingsContentMetrics ConfigMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);
+	const SSettingsContentMetrics ConfigMetrics = ResolveSettingsContentMetrics(MainView.w);
 	const SSettingsPageLayoutFrame Page = SettingsPageLayout(MainView, UiScale);
 	std::unique_ptr<CUiRenderOnlyGuard> pRenderOnlyGuard;
 	if(ReadOnly && !Ui()->RenderOnly())

--- a/src/game/version.h
+++ b/src/game/version.h
@@ -20,7 +20,7 @@ extern const char *GIT_SHORTREV_HASH;
 
 // QmClient
 #ifndef QMCLIENT_VERSION
-#define QMCLIENT_VERSION "3.0.1"
+#define QMCLIENT_VERSION "3.0.2"
 #endif
 
 #define CLIENT_NAME "QmClient"

--- a/src/test/QmAnimTest.cpp
+++ b/src/test/QmAnimTest.cpp
@@ -178,28 +178,6 @@ namespace
 		EXPECT_FLOAT_EQ(Standard.m_SmallSize, ResolveSettingsSmallFontSize(Standard.m_UiScale));
 	}
 
-	TEST(SettingsPageLayout, SettingsFontScaleScalesFontsAndRowsTogether)
-	{
-		EXPECT_FLOAT_EQ(NormalizeSettingsFontScale(100), 1.0f);
-		EXPECT_FLOAT_EQ(NormalizeSettingsFontScale(160), 1.6f);
-		EXPECT_FLOAT_EQ(NormalizeSettingsFontScale(50), 0.80f);
-		EXPECT_FLOAT_EQ(NormalizeSettingsFontScale(300), 1.60f);
-
-		const SSettingsContentMetrics Base = ResolveSettingsContentMetrics(1000.0f, 100);
-		EXPECT_FLOAT_EQ(Base.m_BodySize, ui_token::font::BODY);
-		EXPECT_FLOAT_EQ(Base.m_LineHeight, ui_token::settings::ROW_HEIGHT);
-
-		const SSettingsContentMetrics Large = ResolveSettingsContentMetrics(1000.0f, 160);
-		EXPECT_FLOAT_EQ(Large.m_BodySize, ui_token::font::BODY * 1.5f);
-		EXPECT_GE(Large.m_LineHeight, Large.m_BodySize + 4.0f);
-		EXPECT_GT(Large.m_LineHeight, Base.m_LineHeight);
-
-		// 默认参数（不传 FontScale）应与 100% 一致，保证旧调用点契约
-		const SSettingsContentMetrics Defaulted = ResolveSettingsContentMetrics(1000.0f);
-		EXPECT_FLOAT_EQ(Defaulted.m_BodySize, Base.m_BodySize);
-		EXPECT_FLOAT_EQ(Defaulted.m_LineHeight, Base.m_LineHeight);
-	}
-
 	TEST(SettingsPageLayout, DisplayCycleStateStartsOncePerVisiblePage)
 	{
 		SSettingsCardDeckDisplayCycleState State;

--- a/src/test/qm_new_ui_menu_branch_test.cpp
+++ b/src/test/qm_new_ui_menu_branch_test.cpp
@@ -3064,7 +3064,7 @@ TEST(QmNewUiMenuBranches, QmSettingsCardsUseSharedStyleHelpers)
 
 	for(const std::string *pDeck : {&VisualDeck, &FunctionDeck, &HudDeck})
 	{
-		EXPECT_NE(pDeck->find("ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale)"), std::string::npos);
+		EXPECT_NE(pDeck->find("ResolveSettingsContentMetrics(MainView.w)"), std::string::npos);
 		EXPECT_NE(pDeck->find("CardDeck.RenderCached("), std::string::npos);
 		EXPECT_NE(pDeck->find("ResolveSettingsCardDefinitionsRevision("), std::string::npos);
 		EXPECT_NE(pDeck->find("static std::array<CButtonContainer, QmModuleCount> s_aCollapseButtons;"), std::string::npos);

--- a/src/test/qmclient_monitoring_test.cpp
+++ b/src/test/qmclient_monitoring_test.cpp
@@ -2044,10 +2044,10 @@ TEST(QmMonitoringHelpers, SettingsTextColdStartAvoidsGlobalLanguageCacheAndCache
 		EXPECT_NE(Source.find("DoSettingsButton_CheckBox(SETTINGS_GRAPHICS"), std::string::npos);
 		EXPECT_NE(Source.find("DoSettingsButton_CheckBox(SETTINGS_SOUND"), std::string::npos);
 		EXPECT_NE(Source.find("DoSettingsButton_CheckBox(SETTINGS_DDNET"), std::string::npos);
-		const size_t NewShellMetrics = Source.find("m_SettingsContentMetrics = ResolveSettingsContentMetrics(Shell.m_ContentRect.w, g_Config.m_QmSettingsFontScale);");
+		const size_t NewShellMetrics = Source.find("m_SettingsContentMetrics = ResolveSettingsContentMetrics(Shell.m_ContentRect.w);");
 		const size_t LegacyShellSplit = Source.find("MainView.VSplitRight(TabBarWidth, &MainView, &TabBar);");
 		const size_t LegacyShellMargin = Source.find("MainView.Margin(std::clamp(MainView.w * 0.02f, 12.0f, 20.0f), &MainView);");
-		const size_t LegacyShellMetrics = Source.find("m_SettingsContentMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);");
+		const size_t LegacyShellMetrics = Source.find("m_SettingsContentMetrics = ResolveSettingsContentMetrics(MainView.w);");
 		const size_t FirstPageRender = Source.find("if(g_Config.m_UiSettingsPage == SETTINGS_GENERAL)");
 		ASSERT_NE(NewShellMetrics, std::string::npos);
 		ASSERT_NE(LegacyShellSplit, std::string::npos);

--- a/src/test/settings_warmup_test.cpp
+++ b/src/test/settings_warmup_test.cpp
@@ -2421,14 +2421,14 @@ TEST(SettingsWarmup, RemainingSettingsPagesUseResponsiveContentMetrics)
 	const std::string Assets = ReadTestSourceFile("src/game/client/components/menus_settings_assets.cpp");
 	const std::string Settings = ReadTestSourceFile("src/game/client/components/menus_settings.cpp");
 
-	EXPECT_NE(TClient.find("const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth, g_Config.m_QmSettingsFontScale);"), std::string::npos);
+	EXPECT_NE(TClient.find("const SSettingsContentMetrics Metrics = ResolveSettingsContentMetrics(ContentWidth);"), std::string::npos);
 	EXPECT_NE(TClient.find("FontSize = Metrics.m_BodySize;"), std::string::npos);
 	EXPECT_NE(TClient.find("LineSize = Metrics.m_LineHeight;"), std::string::npos);
 	EXPECT_NE(TClient.find("MarginSmall = Metrics.m_LineSpacing;"), std::string::npos);
 	EXPECT_NE(Controls.find("ApplyControlsContentMetrics(MainView.w);"), std::string::npos);
 	EXPECT_NE(Controls.find("BUTTON_HEIGHT = Metrics.m_LineHeight;"), std::string::npos);
 	EXPECT_NE(Controls.find("BUTTON_SPACING = Metrics.m_LineSpacing;"), std::string::npos);
-	EXPECT_NE(Assets.find("const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(MainView.w, g_Config.m_QmSettingsFontScale);"), std::string::npos);
+	EXPECT_NE(Assets.find("const SSettingsContentMetrics ContentMetrics = ResolveSettingsContentMetrics(MainView.w);"), std::string::npos);
 	EXPECT_NE(Assets.find("Localize(\"Loading assets...\"), ContentMetrics.m_BodySize"), std::string::npos);
 	EXPECT_NE(Assets.find("Localize(\"No assets\"), ContentMetrics.m_BodySize"), std::string::npos);
 	EXPECT_NE(Settings.find("pCheckBoxValue, float LineHeight, float LineSpacing, float BodySize, float ButtonHeight)"), std::string::npos);


### PR DESCRIPTION
fix(qmclient): 移除线性缩放与设置页字体独立缩放

## DEL
- 删除 qm_zoom_linear 与 qm_settings_font_scale 及设置入口，恢复原有镜头缩放和设置页字号、行高。
- 移除独立字体缩放测试，恢复既有布局测试契约。

## FIX
- 保留 PR #182 的构建兼容修复；版本更新至 3.0.2。

验证：只读审查无阻断发现；python qmclient_scripts/gate/check_gate.py --mode quick 通过（11 项）；git diff --check 通过。按要求未编译、未运行测试。
